### PR TITLE
Removing unnecessary files and fixing an unbound envar.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,6 @@
 FROM    docker-registry.eyeosbcn.com/open365-base
 
 ## Install open365-services
-COPY    npmrc /root/.npmrc
-COPY    netrc /root/.netrc
 COPY    package.json /root/
 RUN     apt-get update && \
         DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
@@ -20,8 +18,6 @@ RUN     apt-get update && \
         npm install -g json && \
         /code/open365-services/install.sh && \
         ln -s /usr/bin/env /bin/env && \
-        rm /root/.netrc && \
-        rm /root/.npmrc && \
         apt-get purge -y build-essential
 
 # locale generation

--- a/npmrc
+++ b/npmrc
@@ -1,1 +1,0 @@
-registry = http://artifacts.eyeosbcn.com/nexus/content/groups/npm/

--- a/run.sh
+++ b/run.sh
@@ -80,7 +80,9 @@ if [[ ! -f /home/$SPICE_USER/.eyeosConfigured ]]; then
 fi
 
 #su $SPICE_USER -c "/usr/bin/Xorg -config /etc/X11/spiceqxl.xorg.conf -logfile  /home/$SPICE_USER/.Xorg.2.log :2 &" 2>/dev/null
-
+if [ -z "$LANG" ]; then
+    LANG=en_US.UTF-8
+fi
 /usr/sbin/locale-gen $LANG
 
 rm /tmp/.X2-lock | true


### PR DESCRIPTION
The netrc and npmrc files are no longer required.

We now check that the LANG envar is set and doesn't have an empty value, if so we hardcode it to en_US.UTF-8 to avoid an unbound error.
